### PR TITLE
fix: validación de nombre faltante en página de configuración

### DIFF
--- a/app/dashboard/configuracion/page.tsx
+++ b/app/dashboard/configuracion/page.tsx
@@ -45,6 +45,7 @@ export default function ConfiguracionPage() {
   const { toast } = useToast()
   const { userData, isLoading: userLoading, updateProfile, changePassword } = useUser()
   const [showLogoutModal, setShowLogoutModal] = useState(false)
+  const [nameError, setNameError] = useState("")
   const [profileData, setProfileData] = useState<UserProfile>({
     name: "",
     email: "",
@@ -78,6 +79,11 @@ export default function ConfiguracionPage() {
     : "MG"
 
   const handleSaveProfile = async () => {
+    if (!profileData.name || profileData.name.trim().length === 0) {
+      setNameError("El nombre es requerido")
+      return
+    }
+    setNameError("")
     await updateProfile({
       name: profileData.name,
       phone: profileData.phone,
@@ -174,9 +180,15 @@ export default function ConfiguracionPage() {
             <Input
               id="name"
               value={profileData.name}
-              onChange={(e) => setProfileData({ ...profileData, name: e.target.value })}
-              className="mt-1"
+              onChange={(e) => {
+                setProfileData({ ...profileData, name: e.target.value })
+                if (nameError) setNameError("")
+              }}
+              className={`mt-1 ${nameError ? "border-red-500" : ""}`}
             />
+            {nameError && (
+              <p className="text-xs text-red-500 mt-1">{nameError}</p>
+            )}
           </div>
 
           <div>


### PR DESCRIPTION
## Problema

El endpoint `PUT /api/user/profile` registraba 137 warnings en Sentry con el mensaje `"Invalid name provided in profile update"`. Los eventos ocurrieron desde 2026-02-18 hasta 2026-03-24 (hoy), mayormente desde iOS (Chrome Mobile iOS).

## Causa raíz

La página `/dashboard/configuracion` llamaba `updateProfile({ name: profileData.name, ... })` **sin validar** que el nombre no estuviera vacío. Si un usuario:
- Tenía el nombre vacío en su perfil
- Borraba el campo nombre
- Guardaba solo cambios de zona horaria/teléfono con nombre vacío

...el request llegaba al backend con `name: ""`, que es inválido. El backend rechazaba con 400 y mostraba un toast genérico de error, pero sin indicar qué campo era el problema.

La página `/dashboard/profile` ya tenía esta validación; `/configuracion` la omitía.

## Solución

En `app/dashboard/configuracion/page.tsx`:
- Agregar validación en `handleSaveProfile` antes de llamar a `updateProfile`
- Si el nombre está vacío, mostrar mensaje de error visual en el input (borde rojo + texto)
- Limpiar el error al escribir en el campo

## Archivos modificados

- `app/dashboard/configuracion/page.tsx` — 14 líneas añadidas

## Tests

Los tests existentes pasan (los 23 fallos son preexistentes por configuración de Jest con TSX).

## Cómo probar manualmente

1. Ir a `/dashboard/configuracion`
2. Borrar el campo "Nombre Completo"
3. Hacer clic en "Guardar Cambios"
4. Verificar que aparece error visual en el campo y NO se hace la petición al servidor

Closes #9
🤖 Fix autónomo por Claude | Sentry: JAVASCRIPT-NEXTJS-8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for the profile name field. Empty or whitespace-only names are now prevented from being saved, with a red border and inline error message displayed. Error feedback clears when the field is edited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->