### PR TITLE
fix(deps): fijar ai@4.3.13 (Vercel instalaba v6 y rompía el asistente)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:ci": "jest --ci --coverage --maxWorkers=2"
   },
   "dependencies": {
-    "@ai-sdk/openai": "latest",
+    "@ai-sdk/openai": "1.3.21",
     "@auth/mongodb-adapter": "latest",
     "@aws-sdk/credential-providers": "latest",
     "@google/generative-ai": "^0.24.1",
@@ -60,7 +60,7 @@
     "@types/multer": "^1.4.12",
     "@vercel/blob": "^2.3.0",
     "adm-zip": "^0.5.16",
-    "ai": "latest",
+    "ai": "4.3.13",
     "autoprefixer": "^10.4.20",
     "bcrypt": "^6.0.0",
     "bcryptjs": "latest",


### PR DESCRIPTION
El pnpm-lock.yaml es un stub vacío → Vercel (pnpm) resolvía 'ai: latest' a v6.0.195, donde tool() usa inputSchema en vez de parameters → schema vacío → OpenAI lo rechazaba ('type: None'). Fijar ai@4.3.13 / @ai-sdk/openai@1.3.21 lo soluciona. Confirmado en logs del Preview: '+ ai 4.3.13'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AI SDK dependencies to improved versions for enhanced stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->